### PR TITLE
Add customisation option to display hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,5 @@ Add the following lines to you zsh configuration:
 ZSH_THEME="catppuccin"
 CATPPUCCIN_FLAVOR="mocha" # Required! Options: mocha, flappe, macchiato, latte
 CATPPUCCIN_SHOW_TIME=true  # Optional! If set to true, this will add the current time to the prompt.
+CATPPUCCIN_SHOW_HOSTNAME="never"  # Optional! Options: never, always, ssh
 ```

--- a/catppuccin.zsh-theme
+++ b/catppuccin.zsh-theme
@@ -1,3 +1,7 @@
+# Customisation Options
+: ${CATPPUCCIN_SHOW_HOSTNAME:="never"} # never, always, ssh
+
+
 if [ "$CATPPUCCIN_FLAVOR" = "frappe" ]; then
     source ${0:A:h}/catppuccin-flavors/catppuccin-frappe.zsh
 elif [ "$CATPPUCCIN_FLAVOR" = "latte" ]; then
@@ -8,8 +12,16 @@ else
     source ${0:A:h}/catppuccin-flavors/catppuccin-mocha.zsh
 fi
 
-
 PROMPT="%(?:%F{${catppuccin_green}}%1{➜%} :%F{${catppuccin_red}}%1{➜%} )"
+
+if [ "$CATPPUCCIN_SHOW_HOSTNAME" = "ssh" ]; then
+    if [[ -n "$SSH_CONNECTION" ]]; then
+        PROMPT+="%F{${catppuccin_mauve}}[%m] "
+    fi
+elif [ "$CATPPUCCIN_SHOW_HOSTNAME" = "always" ]; then
+    PROMPT+="%F{${catppuccin_sky}}[%m] "
+fi
+
 if [ "$CATPPUCCIN_SHOW_TIME" = true ];
 then
   PROMPT+="%F{${catppuccin_mauve}}%T%  "


### PR DESCRIPTION
 Added `CATPPUCCIN_SHOW_HOSTNAME` variable to allow users to optionally display hostname.
 
Options include:
- "never" - default behaviour
- "always" - always show hostname
- "ssh" - only show hostname when connected via SSH

Examples:
- always
<img width="682" height="577" alt="Screenshot 2026-01-18 at 1 16 28 pm" src="https://github.com/user-attachments/assets/a4dcb66a-0345-4c8e-a6c5-d0fdcea7599c" />

- ssh
<img width="682" height="577" alt="Screenshot 2026-01-18 at 1 17 11 pm" src="https://github.com/user-attachments/assets/9d7f8c36-ddb6-45fb-985b-f0af84dc660b" />

